### PR TITLE
Implement simple schedule web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
 # WFM-sch-notifiy
-to send MS exchange email based on MS excel scheduels
+
+This project aims to send Microsoft Exchange emails based on schedule data from an Excel or CSV file. The repository now includes a minimal web server implemented with Python's standard library.
+
+## Quick Start
+
+1. Create or update `schedule.csv` with your schedule entries (Date, Task).
+2. Optionally set `SCHEDULE_FILE` to point to a different path.
+3. (Optional) set `SCHEDULE_URL` to a CSV download link from Excel Online to
+   automatically fetch the latest schedule.
+4. Run the server:
+   ```bash
+   python server.py
+   ```
+5. Open `http://localhost:8000` in your browser to view the upcoming schedule.
+
+### Configuration
+
+Environment variables tweak the server:
+
+* `SCHEDULE_FILE` - path to the CSV file
+* `SCHEDULE_URL` - URL to download the CSV on each request
+* `PORT` - port the web server listens on (default `8000`)
+* `DAYS_AHEAD` - number of days of tasks to display (default `7`)
+
+### Email Notifications
+
+Use `notify.py` to send a daily email for tasks scheduled for today:
+
+```bash
+python notify.py
+```
+
+Configure SMTP settings via these environment variables:
+
+* `SMTP_HOST` and `SMTP_PORT`
+* `SMTP_USER` and `SMTP_PASS` if authentication is required
+* `FROM_ADDR` and `TO_ADDR`
+
+This script can be invoked via `cron` to run each morning:
+
+```
+0 6 * * * /usr/bin/python /path/to/notify.py
+```
+
+The web server reads `SCHEDULE_FILE` or downloads from `SCHEDULE_URL` on each
+request and shows the upcoming schedule in a table.

--- a/notify.py
+++ b/notify.py
@@ -1,0 +1,37 @@
+import os
+import smtplib
+from datetime import date
+from email.message import EmailMessage
+
+from server import load_schedule
+
+SMTP_HOST = os.environ.get('SMTP_HOST', 'localhost')
+SMTP_PORT = int(os.environ.get('SMTP_PORT', '25'))
+SMTP_USER = os.environ.get('SMTP_USER')
+SMTP_PASS = os.environ.get('SMTP_PASS')
+FROM_ADDR = os.environ.get('FROM_ADDR', 'noreply@example.com')
+TO_ADDR = os.environ.get('TO_ADDR', 'user@example.com')
+
+
+def send_email(subject, body, to_addr=TO_ADDR):
+    msg = EmailMessage()
+    msg['Subject'] = subject
+    msg['From'] = FROM_ADDR
+    msg['To'] = to_addr
+    msg.set_content(body)
+    with smtplib.SMTP(SMTP_HOST, SMTP_PORT) as s:
+        if SMTP_USER and SMTP_PASS:
+            s.login(SMTP_USER, SMTP_PASS)
+        s.send_message(msg)
+
+
+def notify_today():
+    today = date.today()
+    entries = load_schedule()
+    for e in entries:
+        if e['date'] == today:
+            send_email(f"Task for {today.isoformat()}", e['task'])
+
+
+if __name__ == '__main__':
+    notify_today()

--- a/schedule.csv
+++ b/schedule.csv
@@ -1,0 +1,3 @@
+Date,Task
+2024-05-01,Deploy update
+2024-05-02,Send report

--- a/server.py
+++ b/server.py
@@ -1,0 +1,80 @@
+import csv
+import os
+from datetime import datetime, timedelta
+from urllib.request import urlopen
+from wsgiref.simple_server import make_server
+
+# Number of days ahead to display on the web page
+DAYS_AHEAD = int(os.environ.get("DAYS_AHEAD", "7"))
+# Optional port configuration for the server
+SERVER_PORT = int(os.environ.get("PORT", "8000"))
+
+SCHEDULE_FILE = os.environ.get('SCHEDULE_FILE', 'schedule.csv')
+SCHEDULE_URL = os.environ.get('SCHEDULE_URL')
+
+def load_schedule(path=SCHEDULE_FILE):
+    """Return list of schedule entries as dicts with date objects."""
+    entries = []
+    try:
+        if SCHEDULE_URL:
+            stream = urlopen(SCHEDULE_URL)
+        else:
+            stream = open(path, 'rb')
+        with stream as raw:
+            reader = csv.reader(line.decode('utf-8') for line in raw)
+            next(reader, None)  # drop header
+            for row in reader:
+                if len(row) >= 2:
+                    try:
+                        d = datetime.strptime(row[0], "%Y-%m-%d").date()
+                    except ValueError:
+                        continue
+                    entries.append({'date': d, 'task': row[1]})
+    except FileNotFoundError:
+        pass
+    except Exception:
+        pass
+    return entries
+
+
+def get_upcoming_entries(entries, days=7, start=None):
+    """Return entries within the next ``days`` starting from ``start``."""
+    start = start or datetime.today().date()
+    end = start + timedelta(days=days)
+    upcoming = []
+    for e in entries:
+        if start <= e['date'] <= end:
+            upcoming.append(e)
+    return upcoming
+
+
+def render_table(entries):
+    rows = '\n'.join(
+        f'<tr><td>{e["date"].isoformat()}</td><td>{e["task"]}</td></tr>'
+        for e in entries
+    )
+    return f"""<html><body>
+<h1>Upcoming Schedule</h1>
+<table border='1'>
+<tr><th>Date</th><th>Task</th></tr>
+{rows}
+</table>
+</body></html>"""
+
+
+def application(environ, start_response):
+    entries = load_schedule()
+    upcoming = get_upcoming_entries(entries, days=DAYS_AHEAD)
+    content = render_table(upcoming)
+    start_response('200 OK', [('Content-Type', 'text/html; charset=utf-8')])
+    return [content.encode('utf-8')]
+
+
+def run_server(host='0.0.0.0', port=SERVER_PORT):
+    with make_server(host, port, application) as httpd:
+        print(f'Serving on http://{host}:{port}')
+        httpd.serve_forever()
+
+
+if __name__ == '__main__':
+    run_server()


### PR DESCRIPTION
## Summary
- add sample schedule CSV
- create `server.py` for minimal web server
- document usage in README
- allow fetching schedule CSV from remote URL
- add notifier script for sending daily emails
- show upcoming schedule and support cron email reminders
- expose server port, days to display, and SMTP login via environment variables

## Testing
- `python -m py_compile server.py notify.py`


------
https://chatgpt.com/codex/tasks/task_e_686c462654588324a9bc61dd6a621ce8